### PR TITLE
Untitled

### DIFF
--- a/lib/pdoc/models.rb
+++ b/lib/pdoc/models.rb
@@ -23,6 +23,7 @@ module PDoc
   module Models
     class << Models
       attr_accessor :src_code_href
+      attr_accessor :src_code_text
       attr_accessor :doc_href
     end
     

--- a/lib/pdoc/models/entity.rb
+++ b/lib/pdoc/models/entity.rb
@@ -15,6 +15,10 @@ module PDoc
         proc = Models.src_code_href
         @src_code_href ||= proc ? proc.call(self) : nil
       end
+      
+      def src_code_text
+        @src_code_text ||= Models.src_code_text
+      end
 
       def signatures?
         @signatures && !@signatures.empty?

--- a/lib/pdoc/runner.rb
+++ b/lib/pdoc/runner.rb
@@ -11,6 +11,7 @@ module PDoc
       @serializer          = Serializer
       @bust_cache          = options.delete(:bust_cache) || false
       Models.src_code_href = options.delete(:src_code_href)
+      Models.src_code_text = options.delete(:src_code_text)
       Models.doc_href = options.delete(:doc_href)
       @generator_options = options
     end

--- a/templates/html/assets/stylesheets/pdoc/api.css
+++ b/templates/html/assets/stylesheets/pdoc/api.css
@@ -622,6 +622,9 @@ p.related-to {
   border-right: 1px solid #636363;
   overflow-y: scroll;
   overflow-x: hidden;
+  
+  /* Fixes jagged text in Safari 5. */
+  -webkit-font-smoothing: antialiased;
 }
 
 #search_pane {
@@ -673,5 +676,6 @@ input.ghosted {
   }
 
 #src_code_href {
-	float: right;
+	font-size: 11px;
+	margin: -15px 0 15px 120px;
 }

--- a/templates/html/partials/title.erb
+++ b/templates/html/partials/title.erb
@@ -11,12 +11,14 @@
   <% end %>
 </ul>
 
-<% if object.respond_to?(:src_code_href) && object.src_code_href %>
-  <p id="src_code_href"><a href="<%= object.src_code_href %>">src code</a></p>
-<% end %>
-
 <h2 class="page-title">
   <span class="type"><%= object.type %></span> <%= object.full_name %>
 </h2>
+
+<% if object.respond_to?(:src_code_href) && object.src_code_href %>
+  <% anchor_text = object.respond_to?(:src_code_text) ? object.src_code_text : "View source code &rarr;" %>
+  <p id="src_code_href"><a href="<%= object.src_code_href %>"><%= anchor_text %></a></p>
+<% end %>
+
 
 


### PR DESCRIPTION
Tobie,

Moved the "view source code" anchor — hope you don't mind — and it occurred to me that we'd need a way to customize the text of that link, so I made that another option to `PDoc.run`. Does this look good to you?
